### PR TITLE
Symbolizing arguments passed to Uglifier from _config.yaml

### DIFF
--- a/lib/jekyll/converters/js.rb
+++ b/lib/jekyll/converters/js.rb
@@ -83,7 +83,7 @@ module Jekyll
             )
           )
 
-          uglified, source_map = Uglifier.new(config[:uglifer]).compile_with_map(insert_imports(content))
+          uglified, source_map = Uglifier.new(Jekyll::Utils.symbolize_hash_keys(config[:uglifer])).compile_with_map(insert_imports(content))
 
           @source_map_page.source_map(source_map)
           site.pages << @source_map_page
@@ -97,7 +97,7 @@ module Jekyll
             )
           )
 
-          Uglifier.new(config[:uglifer]).compile(insert_imports(content))
+          Uglifier.new(Jekyll::Utils.symbolize_hash_keys(config[:uglifer])).compile(insert_imports(content))
         end
       end
 


### PR DESCRIPTION
The Jekyll Utils helper method for symbolizing hash keys does not deeply symbolize keys. Therefore, the following configuration in `_config.yaml` results in an error:

```
javascript:
  uglifer:
    harmony: true
```

This is the error, raised by a call to `Uglifier.new(config[:uglifer])`:

>   Conversion error: Jekyll::Converters::Js encountered an error while converting 'assets/js/main.js':
>                     Invalid option: harmony

My solution uses `Jekyll::Utils.symbolize_hash_keys(config[:uglifer])` for the argument to `Uglifier.new()` to work around the issue.